### PR TITLE
add log-friendly rerun_logger crate

### DIFF
--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -55,6 +55,7 @@ wavefront = ["obj"]
 alloc = ["nalgebra/alloc", "hashbrown"]
 spade = ["dep:spade", "alloc"]
 improved_fixed_point_support = []
+log_kv_serde = ["log/kv_serde", "serde-serialize"]
 
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
@@ -66,7 +67,7 @@ path = "../../src/lib.rs"
 required-features = ["required-features"]
 
 [dependencies]
-log = { version = "0.4", features = ["kv", "kv_sval", "kv_serde"] }
+log = { version = "0.4" }
 either = { version = "1", default-features = false }
 bitflags = "2.3"
 downcast-rs = { version = "2", default-features = false, features = ["sync"] }

--- a/crates/parry3d/Cargo.toml
+++ b/crates/parry3d/Cargo.toml
@@ -66,6 +66,7 @@ path = "../../src/lib.rs"
 required-features = ["required-features"]
 
 [dependencies]
+log = { version = "0.4", features = ["kv", "kv_sval", "kv_serde"] }
 either = { version = "1", default-features = false }
 bitflags = "2.3"
 downcast-rs = { version = "2", default-features = false, features = ["sync"] }
@@ -85,7 +86,6 @@ hashbrown = { version = "0.15", optional = true, default-features = false, featu
 spade = { version = "2.9", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
-log = "0.4"
 ordered-float = { version = "5", default-features = false }
 thiserror = { version = "2", default-features = false }
 rstar = "0.12.0"
@@ -100,6 +100,8 @@ macroquad = "0.4.12"
 nalgebra = { version = "0.33", default-features = false, features = ["rand"] }
 rand_isaac = "0.3"
 rerun = "*"
+rerun_logger = { path = "../rerun_logger" }
+serde_json = "*"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]

--- a/crates/rerun_logger/Cargo.toml
+++ b/crates/rerun_logger/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rerun_logger"
+version = "0.0.1"
+authors = ["Thierry Berger <contact@thierryberger.com>"]
+
+description = "3 dimensional collision detection library in Rust."
+documentation = "https://parry.rs/docs"
+homepage = "https://parry.rs"
+repository = "https://github.com/dimforge/parry"
+readme = "README.md"
+keywords = ["collision", "geometry", "distance", "ray", "convex"]
+categories = ["science", "game-development", "mathematics", "wasm"]
+license = "Apache-2.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[lib]
+name = "rerun_logger"
+
+[dependencies]
+log = { version = "0.4", features = ["kv", "kv_sval", "kv_serde"] }
+rerun = "0.22"
+serde_json = "*"
+parry3d = "*"

--- a/crates/rerun_logger/Cargo.toml
+++ b/crates/rerun_logger/Cargo.toml
@@ -21,6 +21,6 @@ name = "rerun_logger"
 
 [dependencies]
 log = { version = "0.4", features = ["kv", "kv_sval", "kv_serde"] }
-rerun = "0.22"
+rerun = "0.23"
 serde_json = "*"
-parry3d = "*"
+parry3d = { version = "0.21", features = ["serde-serialize"] }

--- a/crates/rerun_logger/src/lib.rs
+++ b/crates/rerun_logger/src/lib.rs
@@ -1,12 +1,6 @@
-use std::{
-    cell::RefCell,
-    sync::{atomic::AtomicU32, Arc, RwLock},
-};
+use std::sync::atomic::AtomicU32;
 
-use log::{
-    kv::{Key, Value},
-    Log, Record,
-};
+use log::{Log, Record};
 pub mod parry;
 
 pub struct RerunLogger;
@@ -24,7 +18,7 @@ pub fn init_rr() {
             .unwrap()
     });
 
-    get_rr().set_time_seconds("frame_idx", 0);
+    get_rr().set_duration_secs("sim_time", 0);
 }
 
 pub fn get_rr() -> &'static rerun::RecordingStream {
@@ -48,7 +42,6 @@ impl Log for RerunLogger {
         if !self.enabled(record.metadata()) {
             return;
         }
-        // TODO: check key values, if that's for rerun, log it.
         std::println!(
             "{}:{} -- {}",
             record.level(),

--- a/crates/rerun_logger/src/lib.rs
+++ b/crates/rerun_logger/src/lib.rs
@@ -1,0 +1,65 @@
+use std::{
+    cell::RefCell,
+    sync::{atomic::AtomicU32, Arc, RwLock},
+};
+
+use log::{
+    kv::{Key, Value},
+    Log, Record,
+};
+pub mod parry;
+
+pub struct RerunLogger;
+
+pub static RERUN_LOGGER: RerunLogger = RerunLogger;
+
+static RR_CELL: std::sync::OnceLock<rerun::RecordingStream> = std::sync::OnceLock::new();
+static RECORD: std::sync::OnceLock<RecordFn> = std::sync::OnceLock::new();
+pub static TIME: AtomicU32 = AtomicU32::new(0);
+
+pub fn init_rr() {
+    let _ = RR_CELL.get_or_init(|| {
+        rerun::RecordingStreamBuilder::new("rerun_test_311_convex_hull")
+            .spawn()
+            .unwrap()
+    });
+
+    get_rr().set_time_seconds("frame_idx", 0);
+}
+
+pub fn get_rr() -> &'static rerun::RecordingStream {
+    RR_CELL.get().unwrap()
+}
+pub type RecordFn = Option<Box<dyn Fn(&Record) + Sync + Send>>;
+
+pub fn init_record(record: RecordFn) {
+    RECORD.get_or_init(|| record);
+}
+pub fn get_record() -> &'static RecordFn {
+    RECORD.get_or_init(|| None)
+}
+
+impl Log for RerunLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        // TODO: check key values, if that's for rerun, log it.
+        std::println!(
+            "{}:{} -- {}",
+            record.level(),
+            record.target(),
+            record.args()
+        );
+
+        if let Some(handle_record) = &get_record() {
+            handle_record(record);
+        }
+        //self.forward_logger.log(record);
+    }
+    fn flush(&self) {}
+}

--- a/crates/rerun_logger/src/parry.rs
+++ b/crates/rerun_logger/src/parry.rs
@@ -1,0 +1,91 @@
+use super::get_rr;
+use core::time::Duration;
+use std::boxed::Box;
+
+use parry3d::math::Real;
+use parry3d::{
+    na::Vector3,
+    shape::{TopologyError, TriMeshFlags},
+    transformation::TriangleFacet,
+};
+use rerun::{LineStrip3D, LineStrips3D, Position3D, Vec3D};
+
+/// Calls [super::init_record]
+pub fn init_parry_types() {
+    super::init_record(Some(Box::new(|record| {
+        /// Returns [Ok] if it logged something.
+        fn try_incr_time(record: &log::Record) -> Result<(), ()> {
+            let key_values = record.key_values();
+            let Some(time) = key_values.get(log::kv::Key::from_str("rerun_inc_time")) else {
+                return Err(());
+            };
+            let incr = time.to_u64().unwrap_or(1) as u32;
+            let time = super::TIME.fetch_add(incr, core::sync::atomic::Ordering::Relaxed);
+            std::println!("{}", time + incr);
+            get_rr().set_time_seconds("frame_idx", time + incr);
+            Ok(())
+        }
+        try_incr_time(record);
+        /// Returns [Ok] if it logged something.
+        fn try_log_vec_triangle_facet(record: &log::Record) -> Result<(), ()> {
+            let key_values = record.key_values();
+            let Some(triangle) = key_values.get(log::kv::Key::from_str("rerun_vec_triangles"))
+            else {
+                return Err(());
+            };
+            let Some(points) = key_values.get(log::kv::Key::from_str("points")) else {
+                return Err(());
+            };
+            let triangles_str = serde_json::to_string(&triangle).unwrap();
+            let points_str = serde_json::to_string(&points).unwrap();
+            let triangles = serde_json::from_str::<Vec<TriangleFacet>>(&triangles_str).unwrap();
+            let points = serde_json::from_str::<Vec<Vector3<Real>>>(&points_str).unwrap();
+
+            for (i, TriangleFacet { pts, .. }) in triangles.iter().enumerate() {
+                let (a, b, c) = (pts[0], pts[1], pts[2]);
+                let (a, b, c) = (points[a], points[b], points[c]);
+                let (a, b, c) = (
+                    Vec3D::new(a.x, a.y, a.z),
+                    Vec3D::new(b.x, b.y, b.z),
+                    Vec3D::new(c.x, c.y, c.z),
+                );
+                let ls = LineStrip3D::from_iter([a, b, c, a].iter());
+                //triangles.push(ls);
+                get_rr()
+                    .log(
+                        format!(
+                            "triangle {i}: {}",
+                            record.args().as_str().unwrap_or("triangle facets")
+                        ),
+                        &LineStrips3D::new([ls]),
+                    )
+                    .unwrap();
+            }
+            Ok(())
+        }
+        try_log_vec_triangle_facet(record);
+
+        fn try_log_vec_points(record: &log::Record) -> Result<(), ()> {
+            let key_values = record.key_values();
+            let Some(points) = key_values.get(log::kv::Key::from_str("points")) else {
+                return Err(());
+            };
+            let points_str = serde_json::to_string(&points).unwrap();
+
+            let points = serde_json::from_str::<Vec<Vector3<Real>>>(&points_str).unwrap();
+            get_rr()
+                .log(
+                    format!("points: {}", record.args().as_str().unwrap_or_default()),
+                    &rerun::Points3D::new(
+                        points
+                            .iter()
+                            .map(|p| Vec3D::new(p.x, p.y, p.z))
+                            .collect::<Vec<_>>(),
+                    ),
+                )
+                .unwrap();
+            Ok(())
+        }
+        try_log_vec_points(record);
+    })));
+}

--- a/crates/rerun_logger/src/parry.rs
+++ b/crates/rerun_logger/src/parry.rs
@@ -1,91 +1,148 @@
 use super::get_rr;
-use core::time::Duration;
 use std::boxed::Box;
 
 use parry3d::math::Real;
-use parry3d::{
-    na::Vector3,
-    shape::{TopologyError, TriMeshFlags},
-    transformation::TriangleFacet,
-};
-use rerun::{LineStrip3D, LineStrips3D, Position3D, Vec3D};
+use parry3d::{na::Vector3, transformation::TriangleFacet};
+use rerun::{LineStrip3D, LineStrips3D, Vec3D};
 
 /// Calls [super::init_record]
 pub fn init_parry_types() {
     super::init_record(Some(Box::new(|record| {
-        /// Returns [Ok] if it logged something.
-        fn try_incr_time(record: &log::Record) -> Result<(), ()> {
-            let key_values = record.key_values();
-            let Some(time) = key_values.get(log::kv::Key::from_str("rerun_inc_time")) else {
-                return Err(());
-            };
-            let incr = time.to_u64().unwrap_or(1) as u32;
-            let time = super::TIME.fetch_add(incr, core::sync::atomic::Ordering::Relaxed);
-            std::println!("{}", time + incr);
-            get_rr().set_time_seconds("frame_idx", time + incr);
-            Ok(())
-        }
-        try_incr_time(record);
-        /// Returns [Ok] if it logged something.
-        fn try_log_vec_triangle_facet(record: &log::Record) -> Result<(), ()> {
-            let key_values = record.key_values();
-            let Some(triangle) = key_values.get(log::kv::Key::from_str("rerun_vec_triangles"))
-            else {
-                return Err(());
-            };
-            let Some(points) = key_values.get(log::kv::Key::from_str("points")) else {
-                return Err(());
-            };
-            let triangles_str = serde_json::to_string(&triangle).unwrap();
-            let points_str = serde_json::to_string(&points).unwrap();
-            let triangles = serde_json::from_str::<Vec<TriangleFacet>>(&triangles_str).unwrap();
-            let points = serde_json::from_str::<Vec<Vector3<Real>>>(&points_str).unwrap();
-
-            for (i, TriangleFacet { pts, .. }) in triangles.iter().enumerate() {
-                let (a, b, c) = (pts[0], pts[1], pts[2]);
-                let (a, b, c) = (points[a], points[b], points[c]);
-                let (a, b, c) = (
-                    Vec3D::new(a.x, a.y, a.z),
-                    Vec3D::new(b.x, b.y, b.z),
-                    Vec3D::new(c.x, c.y, c.z),
-                );
-                let ls = LineStrip3D::from_iter([a, b, c, a].iter());
-                //triangles.push(ls);
-                get_rr()
-                    .log(
-                        format!(
-                            "triangle {i}: {}",
-                            record.args().as_str().unwrap_or("triangle facets")
-                        ),
-                        &LineStrips3D::new([ls]),
-                    )
-                    .unwrap();
-            }
-            Ok(())
-        }
-        try_log_vec_triangle_facet(record);
-
-        fn try_log_vec_points(record: &log::Record) -> Result<(), ()> {
-            let key_values = record.key_values();
-            let Some(points) = key_values.get(log::kv::Key::from_str("points")) else {
-                return Err(());
-            };
-            let points_str = serde_json::to_string(&points).unwrap();
-
-            let points = serde_json::from_str::<Vec<Vector3<Real>>>(&points_str).unwrap();
-            get_rr()
-                .log(
-                    format!("points: {}", record.args().as_str().unwrap_or_default()),
-                    &rerun::Points3D::new(
-                        points
-                            .iter()
-                            .map(|p| Vec3D::new(p.x, p.y, p.z))
-                            .collect::<Vec<_>>(),
-                    ),
-                )
-                .unwrap();
-            Ok(())
-        }
-        try_log_vec_points(record);
+        let _ = try_incr_time(record);
+        let _ = try_log_vec_triangle_facet(record);
+        let _ = try_log_vec_points(record);
+        let _ = try_clear(record);
+        let _ = try_log_vertices_indices(record);
     })));
+}
+
+/// Returns [Ok] if it logged something.
+fn try_incr_time(record: &log::Record) -> Result<(), ()> {
+    let key_values = record.key_values();
+    let Some(time) = key_values.get(log::kv::Key::from_str("rerun_inc_time")) else {
+        return Err(());
+    };
+    let incr = time.to_u64().unwrap_or(1) as u32;
+    let time = super::TIME.fetch_add(incr, core::sync::atomic::Ordering::Relaxed);
+    std::println!("{}", time + incr);
+    //get_rr().set_time_seconds("frame_idx", time + incr);
+    get_rr().set_duration_secs("sim_time", time + incr);
+    Ok(())
+}
+
+/// Returns [Ok] if it logged something.
+fn try_log_vec_triangle_facet(record: &log::Record) -> Result<(), ()> {
+    let key_values = record.key_values();
+    let Some(triangle) = key_values.get(log::kv::Key::from_str("parry_vec_triangles")) else {
+        return Err(());
+    };
+    let Some(points) = key_values.get(log::kv::Key::from_str("points")) else {
+        return Err(());
+    };
+    let triangles_str = serde_json::to_string(&triangle).unwrap();
+    let points_str = serde_json::to_string(&points).unwrap();
+    let triangles = serde_json::from_str::<Vec<TriangleFacet>>(&triangles_str).unwrap();
+    let points = serde_json::from_str::<Vec<Vector3<Real>>>(&points_str).unwrap();
+
+    for (i, TriangleFacet { pts, .. }) in triangles.iter().enumerate() {
+        let (a, b, c) = (pts[0], pts[1], pts[2]);
+        let (a, b, c) = (points[a], points[b], points[c]);
+        let (a, b, c) = (
+            Vec3D::new(a.x, a.y, a.z),
+            Vec3D::new(b.x, b.y, b.z),
+            Vec3D::new(c.x, c.y, c.z),
+        );
+        let ls = LineStrip3D::from_iter([a, b, c, a].iter());
+        //triangles.push(ls);
+
+        get_rr()
+            .log(
+                format!(
+                    "{}/{i}/",
+                    record.args().as_str().unwrap_or("triangle facets")
+                ),
+                &LineStrips3D::new([ls]),
+            )
+            .unwrap();
+    }
+    Ok(())
+}
+
+/// Returns [Ok] if it logged something.
+fn try_log_vec_points(record: &log::Record) -> Result<(), ()> {
+    let key_values = record.key_values();
+    let Some(points) = key_values.get(log::kv::Key::from_str("points")) else {
+        return Err(());
+    };
+    let points_str = serde_json::to_string(&points).unwrap();
+
+    let points = serde_json::from_str::<Vec<Vector3<Real>>>(&points_str).unwrap();
+    get_rr()
+        .log(
+            format!("points: {}", record.args().as_str().unwrap_or_default()),
+            &rerun::Points3D::new(
+                points
+                    .iter()
+                    .map(|p| Vec3D::new(p.x, p.y, p.z))
+                    .collect::<Vec<_>>(),
+            ),
+        )
+        .unwrap();
+    Ok(())
+}
+
+/// Returns [Ok] if it logged something.
+fn try_log_vertices_indices(record: &log::Record) -> Result<(), ()> {
+    let key_values = record.key_values();
+    let Some(vertices) = key_values.get(log::kv::Key::from_str("vertices")) else {
+        return Err(());
+    };
+    let Some(indices) = key_values.get(log::kv::Key::from_str("indices")) else {
+        return Err(());
+    };
+    let vertices_str = serde_json::to_string(&vertices).unwrap();
+    let indices_str = serde_json::to_string(&indices).unwrap();
+    let vertices = serde_json::from_str::<Vec<Vector3<Real>>>(&vertices_str).unwrap();
+    let indices = serde_json::from_str::<Vec<[u32; 3]>>(&indices_str).unwrap();
+
+    for (i, [a, b, c]) in indices.iter().enumerate() {
+        let (a, b, c) = (
+            vertices[*a as usize],
+            vertices[*b as usize],
+            vertices[*c as usize],
+        );
+        let (a, b, c) = (
+            Vec3D::new(a.x, a.y, a.z),
+            Vec3D::new(b.x, b.y, b.z),
+            Vec3D::new(c.x, c.y, c.z),
+        );
+        let ls = LineStrip3D::from_iter([a, b, c, a].iter());
+        //triangles.push(ls);
+
+        get_rr()
+            .log(
+                format!(
+                    "{}/{i}/",
+                    record.args().as_str().unwrap_or("triangle facets")
+                ),
+                &LineStrips3D::new([ls]),
+            )
+            .unwrap();
+    }
+    Ok(())
+}
+
+/// Returns [Ok] if it logged something.
+fn try_clear(record: &log::Record) -> Result<(), ()> {
+    let key_values = record.key_values();
+    let Some(clear_name) = key_values.get(log::kv::Key::from_str("clear")) else {
+        return Err(());
+    };
+    let clear_name = serde_json::to_string(&clear_name).unwrap();
+    let clear_name = serde_json::from_str::<String>(&clear_name).unwrap();
+    println!("CLEAR: {clear_name:?}");
+    get_rr()
+        .log(clear_name, &rerun::Clear::recursive())
+        .unwrap();
+    Ok(())
 }

--- a/src/shape/convex_polyhedron.rs
+++ b/src/shape/convex_polyhedron.rs
@@ -667,14 +667,10 @@ impl ConvexPolyhedron for ConvexPolyhedron {
 #[cfg(test)]
 mod tests {
     use core::time::Duration;
-    use std::boxed::Box;
-
-    use na::Vector3;
-    use rerun::{LineStrip3D, LineStrips3D, Position3D, Vec3D};
 
     use crate::{
+        log_kv,
         shape::{TopologyError, TriMeshFlags},
-        transformation::TriangleFacet,
     };
 
     use super::*;
@@ -682,9 +678,12 @@ mod tests {
     #[test]
     fn test_311_convex_hull() {
         log::set_max_level(log::LevelFilter::Debug);
-        rerun_logger::init_rr();
-        rerun_logger::parry::init_parry_types();
-        log::set_logger(&rerun_logger::RERUN_LOGGER);
+        #[cfg(feature = "log_kv_serde")]
+        {
+            rerun_logger::init_rr();
+            rerun_logger::parry::init_parry_types();
+            log::set_logger(&rerun_logger::RERUN_LOGGER);
+        }
 
         let points: Vec<Point<Real>> = vec![
             [-0.9759494, 0.08367488, 1.1975889].into(),
@@ -697,7 +696,9 @@ mod tests {
         let convex = ConvexPolyhedron::from_convex_hull(&points)
             .expect("Failed to compute convex hull of mesh");
 
-        let (vertices, mut indices) = convex.to_trimesh();
+        let (vertices, indices) = convex.to_trimesh();
+        log_kv!(debug, vertices:serde = &vertices, indices:serde = &indices; "to_trimesh");
+
         let mut convex_mesh = crate::shape::TriMesh::new(vertices, indices)
             .expect("Failed to convert convex polyhedron to triangle mesh");
 

--- a/src/shape/convex_polyhedron.rs
+++ b/src/shape/convex_polyhedron.rs
@@ -666,25 +666,27 @@ impl ConvexPolyhedron for ConvexPolyhedron {
 */
 #[cfg(test)]
 mod tests {
-    static RR_CELL: std::sync::OnceLock<rerun::RecordingStream> = std::sync::OnceLock::new();
+    use core::time::Duration;
+    use std::boxed::Box;
 
-    pub fn get_rr() -> &'static rerun::RecordingStream {
-        RR_CELL.get().unwrap()
-    }
+    use na::Vector3;
     use rerun::{LineStrip3D, LineStrips3D, Position3D, Vec3D};
 
-    use crate::shape::{TopologyError, TriMeshFlags};
+    use crate::{
+        shape::{TopologyError, TriMeshFlags},
+        transformation::TriangleFacet,
+    };
 
     use super::*;
 
     #[test]
     fn test_311_convex_hull() {
-        let _ = RR_CELL.get_or_init(|| {
-            rerun::RecordingStreamBuilder::new("rerun_test_311_convex_hull")
-                .spawn()
-                .unwrap()
-        });
-        let mut points: Vec<Point<Real>> = vec![
+        log::set_max_level(log::LevelFilter::Debug);
+        rerun_logger::init_rr();
+        rerun_logger::parry::init_parry_types();
+        log::set_logger(&rerun_logger::RERUN_LOGGER);
+
+        let points: Vec<Point<Real>> = vec![
             [-0.9759494, 0.08367488, 1.1975889].into(),
             [-0.9760843, 0.08125789, 1.2047149].into(),
             [-0.9695144, 0.08282869, 1.2013979].into(),
@@ -692,44 +694,10 @@ mod tests {
             [-0.55810887, -0.47650382, 1.4873786].into(),
         ];
 
-        std::dbg!(points.len());
-        get_rr().set_time_seconds("frame_idx", 0);
-        get_rr()
-            .log(
-                "points",
-                &rerun::Points3D::new(
-                    points
-                        .iter()
-                        .map(|p| Vec3D::new(p.x, p.y, p.z))
-                        .collect::<Vec<_>>(),
-                ),
-            )
-            .unwrap();
         let convex = ConvexPolyhedron::from_convex_hull(&points)
             .expect("Failed to compute convex hull of mesh");
 
         let (vertices, mut indices) = convex.to_trimesh();
-
-        get_rr().set_time_seconds("frame_idx", 1);
-        //let mut triangles = Vec::new();
-        for (i, [a, b, c]) in indices.iter().enumerate() {
-            let (a, b, c) = (
-                vertices[*a as usize],
-                vertices[*b as usize],
-                vertices[*c as usize],
-            );
-            let (a, b, c) = (
-                Vec3D::new(a.x, a.y, a.z),
-                Vec3D::new(b.x, b.y, b.z),
-                Vec3D::new(c.x, c.y, c.z),
-            );
-            let ls = LineStrip3D::from_iter([a, b, c, a].iter());
-            //triangles.push(ls);
-            get_rr()
-                .log(format!("triangle {i}"), &LineStrips3D::new([ls]))
-                .unwrap();
-        }
-        get_rr().set_time_seconds("frame_idx", 2);
         let mut convex_mesh = crate::shape::TriMesh::new(vertices, indices)
             .expect("Failed to convert convex polyhedron to triangle mesh");
 
@@ -738,6 +706,6 @@ mod tests {
             std::dbg!(convex_mesh.set_flags(TriMeshFlags::HALF_EDGE_TOPOLOGY)),
             Err(TopologyError::BadAdjacentTrianglesOrientation { .. })
         ));
-        loop {}
+        std::thread::sleep(Duration::from_secs_f32(3f32));
     }
 }

--- a/src/transformation/convex_hull3/convex_hull.rs
+++ b/src/transformation/convex_hull3/convex_hull.rs
@@ -21,6 +21,7 @@ pub fn try_convex_hull(
     }
 
     // print_buildable_vec("input", points);
+    log::debug!(points:serde; "Input points");
 
     let mut normalized_points = points.to_vec();
     let _ = normalize(&mut normalized_points[..]);
@@ -40,6 +41,7 @@ pub fn try_convex_hull(
             return Ok((vertices, indices));
         }
     }
+    log::debug!(rerun_vec_triangles:serde = triangles, points:serde = normalized_points, rerun_inc_time = 1; "Facets");
 
     let mut i = 0;
     while i != triangles.len() {

--- a/src/transformation/convex_hull3/convex_hull.rs
+++ b/src/transformation/convex_hull3/convex_hull.rs
@@ -3,7 +3,7 @@ use super::{ConvexHullError, TriangleFacet};
 use crate::math::Real;
 use crate::transformation::convex_hull_utils::indexed_support_point_nth;
 use crate::transformation::convex_hull_utils::{indexed_support_point_id, normalize};
-use crate::utils;
+use crate::{log_kv, utils};
 use alloc::{vec, vec::Vec};
 use na::{self, Point3};
 
@@ -21,7 +21,7 @@ pub fn try_convex_hull(
     }
 
     // print_buildable_vec("input", points);
-    log::debug!(points:serde; "Input points");
+    log_kv!(debug, points:serde; "Input points");
 
     let mut normalized_points = points.to_vec();
     let _ = normalize(&mut normalized_points[..]);
@@ -41,7 +41,12 @@ pub fn try_convex_hull(
             return Ok((vertices, indices));
         }
     }
-    log::debug!(rerun_vec_triangles:serde = triangles, points:serde = normalized_points, rerun_inc_time = 1; "Facets");
+    log_kv!(
+        debug, rerun_inc_time = 1, parry_vec_triangles:serde = triangles, points:serde = normalized_points; "Facets"
+    );
+    log_kv!(
+        debug, rerun_inc_time = 1, clear = "Facets"; "Clear Facets"
+    );
 
     let mut i = 0;
     while i != triangles.len() {
@@ -140,6 +145,18 @@ pub fn try_convex_hull(
 
     let mut idx = Vec::new();
 
+    log_kv!(
+        debug,
+        parry_vec_triangles:serde = {
+            let mut valid_triangles = triangles.clone();
+            valid_triangles.retain(|f| f.valid);
+            valid_triangles
+        },
+        points:serde = normalized_points; "Valid_Facets"
+    );
+    log_kv!(
+        debug, rerun_inc_time = 1, clear = "Valid_Facets"; "Clear Facets"
+    );
     for facet in triangles.iter() {
         if facet.valid {
             idx.push([

--- a/src/transformation/convex_hull3/mod.rs
+++ b/src/transformation/convex_hull3/mod.rs
@@ -1,6 +1,6 @@
 pub use self::error::ConvexHullError;
 use self::initial_mesh::{try_get_initial_mesh, InitialMesh};
-use self::triangle_facet::TriangleFacet;
+pub use self::triangle_facet::TriangleFacet;
 use self::validation::check_facet_links;
 pub use convex_hull::{convex_hull, try_convex_hull};
 #[cfg(feature = "std")]

--- a/src/transformation/convex_hull3/triangle_facet.rs
+++ b/src/transformation/convex_hull3/triangle_facet.rs
@@ -6,7 +6,7 @@ use na::{Point3, Vector3};
 use num::Bounded;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TriangleFacet {
     pub valid: bool,
     pub affinely_dependent: bool,

--- a/src/transformation/convex_hull3/triangle_facet.rs
+++ b/src/transformation/convex_hull3/triangle_facet.rs
@@ -1,9 +1,11 @@
 use crate::math::Real;
 use crate::shape::Triangle;
 use alloc::vec::Vec;
+use log::kv::ToValue;
 use na::{Point3, Vector3};
 use num::Bounded;
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct TriangleFacet {
     pub valid: bool,
@@ -15,6 +17,13 @@ pub struct TriangleFacet {
     pub visible_points: Vec<usize>,
     pub furthest_point: usize,
     pub furthest_distance: Real,
+}
+
+impl ToValue for TriangleFacet {
+    fn to_value(&self) -> log::kv::Value {
+        // TODO: save a deserializable value, maybe a `Fill`?
+        log::kv::Value::from_debug(self)
+    }
 }
 
 impl TriangleFacet {

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -19,8 +19,6 @@ pub use self::polygon_intersection::{
     convex_polygons_intersection_with_tolerances, polygons_intersection,
     polygons_intersection_points,
 };
-#[cfg(feature = "dim2")]
-pub use convex_hull2::TriangleFacet;
 #[cfg(feature = "dim3")]
 pub use convex_hull3::TriangleFacet;
 

--- a/src/transformation/mod.rs
+++ b/src/transformation/mod.rs
@@ -19,6 +19,10 @@ pub use self::polygon_intersection::{
     convex_polygons_intersection_with_tolerances, polygons_intersection,
     polygons_intersection_points,
 };
+#[cfg(feature = "dim2")]
+pub use convex_hull2::TriangleFacet;
+#[cfg(feature = "dim3")]
+pub use convex_hull3::TriangleFacet;
 
 mod convex_hull2;
 #[cfg(feature = "dim3")]

--- a/src/transformation/to_trimesh/convex_polyhedron_to_trimesh.rs
+++ b/src/transformation/to_trimesh/convex_polyhedron_to_trimesh.rs
@@ -1,3 +1,4 @@
+use crate::log_kv;
 use crate::math::Real;
 use crate::shape::ConvexPolyhedron;
 use alloc::vec::Vec;

--- a/src/utils/log_kv.rs
+++ b/src/utils/log_kv.rs
@@ -1,0 +1,22 @@
+#[macro_export]
+/// log only if `log_kv_serde` feature is enabled, in order to be able to pass key values.
+/// First argument is the debug level, then regular `log` arguments.
+///
+/// Example usage:
+///
+/// ```rs
+/// log_kv!(debug, key1:serde = 1, key2:serde = "a string"; "Some description");
+/// ```
+macro_rules! log_kv {
+    ($level:ident, $($arg:tt)*) => {
+        #[cfg(feature = "log_kv_serde")]
+        {
+            log::$level!($($arg)*);
+        }
+
+        #[cfg(not(feature = "log_kv_serde"))]
+        {
+            // Do nothing
+        }
+    };
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -55,6 +55,8 @@ pub mod hashset;
 mod interval;
 mod inv;
 mod isometry_ops;
+#[macro_use]
+mod log_kv;
 mod median;
 mod obb;
 mod point_cloud_support_point;


### PR DESCRIPTION
This PR explores adding rerun logging capability to help with debugging.

To try this out, run `cargo test  -p parry3d test_311_convex_hull --features log_kv_serde`, this will prompt you to install [rerun](https://rerun.io/).

https://github.com/user-attachments/assets/2e4cb8c7-97c2-4bb1-8507-f0bc6331642c


